### PR TITLE
fix flaky tests that depend on NODE_ENV = 'test'

### DIFF
--- a/helpers/jasmine.js
+++ b/helpers/jasmine.js
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = "test";

--- a/spec/init.spec.ts
+++ b/spec/init.spec.ts
@@ -1,0 +1,1 @@
+import "../helpers/jasmine";

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,10 +2,8 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist-spec",
-    "sourceMap": true
+    "sourceMap": true,
+    "allowJs": true
   },
-  "include": [
-    "./spec/**/*",
-    "./src/**/*"
-  ]
+  "include": ["./spec/**/*", "./src/**/*"]
 }


### PR DESCRIPTION
This pull request makes improvements to the test environment setup and TypeScript configuration for the project. The main changes ensure that tests have the correct environment variables set, allow JavaScript files in the test build, and properly initialize the test environment.

Test environment setup:

* Added `process.env.NODE_ENV = "test";` to `helpers/jasmine.js` to ensure the test environment variable is set during test runs.
* Imported the `helpers/jasmine` setup in `spec/init.spec.ts` to ensure typescript includes helpers in the spec_dir.

TypeScript configuration:

* Updated `tsconfig.test.json` to allow JavaScript files (`allowJs: true`) in the test build, improving compatibility with mixed TypeScript/JavaScript codebases.